### PR TITLE
Use use-sync-external-store shim so that react-yjs is backwards compatible

### DIFF
--- a/packages/react-yjs/package-lock.json
+++ b/packages/react-yjs/package-lock.json
@@ -1,0 +1,752 @@
+{
+  "name": "react-yjs",
+  "version": "2.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "react-yjs",
+      "version": "2.0.0",
+      "dependencies": {
+        "lib0": "^0.2.94",
+        "use-sync-external-store": "^1.2.2"
+      },
+      "devDependencies": {
+        "@testing-library/dom": "^10.1.0",
+        "@testing-library/jest-dom": "^6.4.6",
+        "@testing-library/react": "^16.0.0",
+        "@types/react": "^18.2.66",
+        "@types/use-sync-external-store": "^0.0.6",
+        "react": "^18.2.0",
+        "vite": "^5.2.13",
+        "vitest": "^1.6.0",
+        "yjs": "^13.6.16"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "yjs": "^13.6.16"
+      }
+    },
+    "../../node_modules/.pnpm/@testing-library+dom@10.1.0/node_modules/@testing-library/dom": {
+      "version": "10.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^5.11.6",
+        "browserslist": "4.21.8",
+        "caniuse-lite": "1.0.30001502",
+        "jest-in-case": "^1.0.2",
+        "jest-snapshot-serializer-ansi": "^1.0.0",
+        "jest-watch-select-projects": "^2.0.0",
+        "jsdom": "20.0.0",
+        "kcd-scripts": "^13.0.0",
+        "typescript": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "../../node_modules/.pnpm/@testing-library+jest-dom@6.4.6_vitest@1.6.0_@types+node@20.14.2_jsdom@24.1.0_terser@5.31.1_/node_modules/@testing-library/jest-dom": {
+      "version": "6.4.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "@babel/runtime": "^7.9.2",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "lodash": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "devDependencies": {
+        "@jest/globals": "^29.6.2",
+        "@rollup/plugin-commonjs": "^25.0.4",
+        "@types/bun": "latest",
+        "@types/web": "latest",
+        "expect": "^29.6.2",
+        "jest-environment-jsdom-sixteen": "^1.0.3",
+        "jest-watch-select-projects": "^2.0.0",
+        "jsdom": "^16.2.1",
+        "kcd-scripts": "^14.0.0",
+        "pretty-format": "^25.1.0",
+        "rollup": "^3.28.1",
+        "rollup-plugin-delete": "^2.0.0",
+        "typescript": "^5.1.6",
+        "vitest": "^0.34.1"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@jest/globals": ">= 28",
+        "@types/bun": "latest",
+        "@types/jest": ">= 28",
+        "jest": ">= 28",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "@jest/globals": {
+          "optional": true
+        },
+        "@types/bun": {
+          "optional": true
+        },
+        "@types/jest": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/.pnpm/@testing-library+react@16.0.0_@testing-library+dom@10.1.0_@types+react-dom@18.3.0_@types+reac_im3bokl2jprakxpuj4llml5tdm/node_modules/@testing-library/react": {
+      "version": "16.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "devDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@testing-library/jest-dom": "^5.11.6",
+        "@types/react": "^18.3.1",
+        "@types/react-dom": "^18.3.0",
+        "chalk": "^4.1.2",
+        "dotenv-cli": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "kcd-scripts": "^13.0.0",
+        "npm-run-all": "^4.1.5",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.0",
+        "rimraf": "^3.0.2",
+        "typescript": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/.pnpm/@types+react@18.3.3/node_modules/@types/react": {
+      "version": "18.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "../../node_modules/.pnpm/lib0@0.2.94/node_modules/lib0": {
+      "version": "0.2.94",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "devDependencies": {
+        "@types/node": "^18.14.0",
+        "c8": "^7.13.0",
+        "jsdoc-api": "^8.0.0",
+        "jsdoc-plugin-typescript": "^2.2.1",
+        "rollup": "^2.42.1",
+        "standard": "^17.1.0",
+        "typescript": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "../../node_modules/.pnpm/react@18.3.1/node_modules/react": {
+      "version": "18.3.1",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/.pnpm/vite@5.2.13_@types+node@20.14.2_terser@5.31.1/node_modules/vite": {
+      "version": "5.2.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.20.1",
+        "postcss": "^8.4.38",
+        "rollup": "^4.13.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "devDependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@babel/parser": "^7.24.6",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@polka/compression": "^1.0.0-next.25",
+        "@rollup/plugin-alias": "^5.1.0",
+        "@rollup/plugin-commonjs": "^25.0.8",
+        "@rollup/plugin-dynamic-import-vars": "^2.1.2",
+        "@rollup/plugin-json": "^6.1.0",
+        "@rollup/plugin-node-resolve": "15.2.3",
+        "@rollup/plugin-typescript": "^11.1.6",
+        "@rollup/pluginutils": "^5.1.0",
+        "@types/escape-html": "^1.0.4",
+        "@types/pnpapi": "^0.0.5",
+        "acorn": "^8.11.3",
+        "acorn-walk": "^8.3.2",
+        "artichokie": "^0.2.1",
+        "cac": "^6.7.14",
+        "chokidar": "^3.6.0",
+        "connect": "^3.7.0",
+        "convert-source-map": "^2.0.0",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.3",
+        "debug": "^4.3.4",
+        "dep-types": "link:./src/types",
+        "dotenv": "^16.4.5",
+        "dotenv-expand": "^11.0.6",
+        "es-module-lexer": "^1.5.3",
+        "escape-html": "^1.0.3",
+        "estree-walker": "^3.0.3",
+        "etag": "^1.8.1",
+        "fast-glob": "^3.3.2",
+        "http-proxy": "^1.18.1",
+        "launch-editor-middleware": "^2.6.1",
+        "lightningcss": "^1.25.1",
+        "magic-string": "^0.30.10",
+        "micromatch": "^4.0.7",
+        "mlly": "^1.7.0",
+        "mrmime": "^2.0.0",
+        "open": "^8.4.2",
+        "parse5": "^7.1.2",
+        "pathe": "^1.1.2",
+        "periscopic": "^4.0.2",
+        "picocolors": "^1.0.1",
+        "picomatch": "^2.3.1",
+        "postcss-import": "^16.1.0",
+        "postcss-load-config": "^4.0.2",
+        "postcss-modules": "^6.0.0",
+        "resolve.exports": "^2.0.2",
+        "rollup-plugin-dts": "^6.1.1",
+        "rollup-plugin-esbuild": "^6.1.1",
+        "rollup-plugin-license": "^3.4.0",
+        "sass": "^1.77.2",
+        "sirv": "^2.0.4",
+        "source-map-support": "^0.5.21",
+        "strip-ansi": "^7.1.0",
+        "strip-literal": "^2.1.0",
+        "tsconfck": "^3.0.3",
+        "tslib": "^2.6.2",
+        "types": "link:./types",
+        "ufo": "^1.5.3",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/.pnpm/vitest@1.6.0_@types+node@20.14.2_jsdom@24.1.0_terser@5.31.1/node_modules/vitest": {
+      "version": "1.6.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.0",
+        "@vitest/runner": "1.6.0",
+        "@vitest/snapshot": "1.6.0",
+        "@vitest/spy": "1.6.0",
+        "@vitest/utils": "1.6.0",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.0",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "devDependencies": {
+        "@ampproject/remapping": "^2.2.1",
+        "@antfu/install-pkg": "^0.3.1",
+        "@edge-runtime/vm": "^3.1.8",
+        "@sinonjs/fake-timers": "11.1.0",
+        "@types/estree": "^1.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/jsdom": "^21.1.6",
+        "@types/micromatch": "^4.0.6",
+        "@types/node": "^20.11.5",
+        "@types/prompts": "^2.4.9",
+        "@types/sinonjs__fake-timers": "^8.1.5",
+        "birpc": "0.2.15",
+        "cac": "^6.7.14",
+        "chai-subset": "^1.6.0",
+        "cli-truncate": "^4.0.0",
+        "expect-type": "^0.17.3",
+        "fast-glob": "^3.3.2",
+        "find-up": "^6.3.0",
+        "flatted": "^3.2.9",
+        "get-tsconfig": "^4.7.3",
+        "happy-dom": "^14.3.10",
+        "jsdom": "^24.0.0",
+        "log-update": "^5.0.1",
+        "micromatch": "^4.0.5",
+        "p-limit": "^5.0.0",
+        "pretty-format": "^29.7.0",
+        "prompts": "^2.4.2",
+        "strip-ansi": "^7.1.0",
+        "ws": "^8.14.2"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.0",
+        "@vitest/ui": "1.6.0",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/.pnpm/yjs@13.6.16/node_modules/yjs": {
+      "version": "13.6.16",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.86"
+      },
+      "devDependencies": {
+        "@rollup/plugin-commonjs": "^24.0.1",
+        "@rollup/plugin-node-resolve": "^15.0.1",
+        "@types/node": "^18.15.5",
+        "concurrently": "^3.6.1",
+        "http-server": "^0.12.3",
+        "jsdoc": "^3.6.7",
+        "markdownlint-cli": "^0.23.2",
+        "rollup": "^3.20.0",
+        "standard": "^16.0.4",
+        "tui-jsdoc-template": "^1.2.2",
+        "typescript": "^4.9.5",
+        "y-protocols": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "resolved": "../../node_modules/.pnpm/@testing-library+dom@10.1.0/node_modules/@testing-library/dom",
+      "link": true
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "resolved": "../../node_modules/.pnpm/@testing-library+jest-dom@6.4.6_vitest@1.6.0_@types+node@20.14.2_jsdom@24.1.0_terser@5.31.1_/node_modules/@testing-library/jest-dom",
+      "link": true
+    },
+    "node_modules/@testing-library/react": {
+      "resolved": "../../node_modules/.pnpm/@testing-library+react@16.0.0_@testing-library+dom@10.1.0_@types+react-dom@18.3.0_@types+reac_im3bokl2jprakxpuj4llml5tdm/node_modules/@testing-library/react",
+      "link": true
+    },
+    "node_modules/@types/react": {
+      "resolved": "../../node_modules/.pnpm/@types+react@18.3.3/node_modules/@types/react",
+      "link": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "dev": true
+    },
+    "node_modules/lib0": {
+      "resolved": "../../node_modules/.pnpm/lib0@0.2.94/node_modules/lib0",
+      "link": true
+    },
+    "node_modules/react": {
+      "resolved": "../../node_modules/.pnpm/react@18.3.1/node_modules/react",
+      "link": true
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "resolved": "../../node_modules/.pnpm/vite@5.2.13_@types+node@20.14.2_terser@5.31.1/node_modules/vite",
+      "link": true
+    },
+    "node_modules/vitest": {
+      "resolved": "../../node_modules/.pnpm/vitest@1.6.0_@types+node@20.14.2_jsdom@24.1.0_terser@5.31.1/node_modules/vitest",
+      "link": true
+    },
+    "node_modules/yjs": {
+      "resolved": "../../node_modules/.pnpm/yjs@13.6.16/node_modules/yjs",
+      "link": true
+    }
+  },
+  "dependencies": {
+    "@testing-library/dom": {
+      "version": "file:../../node_modules/.pnpm/@testing-library+dom@10.1.0/node_modules/@testing-library/dom",
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/jest-dom": "^5.11.6",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "browserslist": "4.21.8",
+        "caniuse-lite": "1.0.30001502",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "jest-in-case": "^1.0.2",
+        "jest-snapshot-serializer-ansi": "^1.0.0",
+        "jest-watch-select-projects": "^2.0.0",
+        "jsdom": "20.0.0",
+        "kcd-scripts": "^13.0.0",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2",
+        "typescript": "^4.1.2"
+      }
+    },
+    "@testing-library/jest-dom": {
+      "version": "file:../../node_modules/.pnpm/@testing-library+jest-dom@6.4.6_vitest@1.6.0_@types+node@20.14.2_jsdom@24.1.0_terser@5.31.1_/node_modules/@testing-library/jest-dom",
+      "requires": {
+        "@adobe/css-tools": "^4.4.0",
+        "@babel/runtime": "^7.9.2",
+        "@jest/globals": "^29.6.2",
+        "@rollup/plugin-commonjs": "^25.0.4",
+        "@types/bun": "latest",
+        "@types/web": "latest",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "expect": "^29.6.2",
+        "jest-environment-jsdom-sixteen": "^1.0.3",
+        "jest-watch-select-projects": "^2.0.0",
+        "jsdom": "^16.2.1",
+        "kcd-scripts": "^14.0.0",
+        "lodash": "^4.17.21",
+        "pretty-format": "^25.1.0",
+        "redent": "^3.0.0",
+        "rollup": "^3.28.1",
+        "rollup-plugin-delete": "^2.0.0",
+        "typescript": "^5.1.6",
+        "vitest": "^0.34.1"
+      }
+    },
+    "@testing-library/react": {
+      "version": "file:../../node_modules/.pnpm/@testing-library+react@16.0.0_@testing-library+dom@10.1.0_@types+react-dom@18.3.0_@types+reac_im3bokl2jprakxpuj4llml5tdm/node_modules/@testing-library/react",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^10.0.0",
+        "@testing-library/jest-dom": "^5.11.6",
+        "@types/react": "^18.3.1",
+        "@types/react-dom": "^18.3.0",
+        "chalk": "^4.1.2",
+        "dotenv-cli": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "kcd-scripts": "^13.0.0",
+        "npm-run-all": "^4.1.5",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.0",
+        "rimraf": "^3.0.2",
+        "typescript": "^4.1.2"
+      }
+    },
+    "@types/react": {
+      "version": "file:../../node_modules/.pnpm/@types+react@18.3.3/node_modules/@types/react",
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "dev": true
+    },
+    "lib0": {
+      "version": "file:../../node_modules/.pnpm/lib0@0.2.94/node_modules/lib0",
+      "requires": {
+        "@types/node": "^18.14.0",
+        "c8": "^7.13.0",
+        "isomorphic.js": "^0.2.4",
+        "jsdoc-api": "^8.0.0",
+        "jsdoc-plugin-typescript": "^2.2.1",
+        "rollup": "^2.42.1",
+        "standard": "^17.1.0",
+        "typescript": "^5.0.2"
+      }
+    },
+    "react": {
+      "version": "file:../../node_modules/.pnpm/react@18.3.1/node_modules/react",
+      "requires": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "requires": {}
+    },
+    "vite": {
+      "version": "file:../../node_modules/.pnpm/vite@5.2.13_@types+node@20.14.2_terser@5.31.1/node_modules/vite",
+      "requires": {
+        "@ampproject/remapping": "^2.3.0",
+        "@babel/parser": "^7.24.6",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@polka/compression": "^1.0.0-next.25",
+        "@rollup/plugin-alias": "^5.1.0",
+        "@rollup/plugin-commonjs": "^25.0.8",
+        "@rollup/plugin-dynamic-import-vars": "^2.1.2",
+        "@rollup/plugin-json": "^6.1.0",
+        "@rollup/plugin-node-resolve": "15.2.3",
+        "@rollup/plugin-typescript": "^11.1.6",
+        "@rollup/pluginutils": "^5.1.0",
+        "@types/escape-html": "^1.0.4",
+        "@types/pnpapi": "^0.0.5",
+        "acorn": "^8.11.3",
+        "acorn-walk": "^8.3.2",
+        "artichokie": "^0.2.1",
+        "cac": "^6.7.14",
+        "chokidar": "^3.6.0",
+        "connect": "^3.7.0",
+        "convert-source-map": "^2.0.0",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.3",
+        "debug": "^4.3.4",
+        "dep-types": "link:./src/types",
+        "dotenv": "^16.4.5",
+        "dotenv-expand": "^11.0.6",
+        "es-module-lexer": "^1.5.3",
+        "esbuild": "^0.20.1",
+        "escape-html": "^1.0.3",
+        "estree-walker": "^3.0.3",
+        "etag": "^1.8.1",
+        "fast-glob": "^3.3.2",
+        "fsevents": "~2.3.3",
+        "http-proxy": "^1.18.1",
+        "launch-editor-middleware": "^2.6.1",
+        "lightningcss": "^1.25.1",
+        "magic-string": "^0.30.10",
+        "micromatch": "^4.0.7",
+        "mlly": "^1.7.0",
+        "mrmime": "^2.0.0",
+        "open": "^8.4.2",
+        "parse5": "^7.1.2",
+        "pathe": "^1.1.2",
+        "periscopic": "^4.0.2",
+        "picocolors": "^1.0.1",
+        "picomatch": "^2.3.1",
+        "postcss": "^8.4.38",
+        "postcss-import": "^16.1.0",
+        "postcss-load-config": "^4.0.2",
+        "postcss-modules": "^6.0.0",
+        "resolve.exports": "^2.0.2",
+        "rollup": "^4.13.0",
+        "rollup-plugin-dts": "^6.1.1",
+        "rollup-plugin-esbuild": "^6.1.1",
+        "rollup-plugin-license": "^3.4.0",
+        "sass": "^1.77.2",
+        "sirv": "^2.0.4",
+        "source-map-support": "^0.5.21",
+        "strip-ansi": "^7.1.0",
+        "strip-literal": "^2.1.0",
+        "tsconfck": "^3.0.3",
+        "tslib": "^2.6.2",
+        "types": "link:./types",
+        "ufo": "^1.5.3",
+        "ws": "^8.17.0"
+      }
+    },
+    "vitest": {
+      "version": "file:../../node_modules/.pnpm/vitest@1.6.0_@types+node@20.14.2_jsdom@24.1.0_terser@5.31.1/node_modules/vitest",
+      "requires": {
+        "@ampproject/remapping": "^2.2.1",
+        "@antfu/install-pkg": "^0.3.1",
+        "@edge-runtime/vm": "^3.1.8",
+        "@sinonjs/fake-timers": "11.1.0",
+        "@types/estree": "^1.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/jsdom": "^21.1.6",
+        "@types/micromatch": "^4.0.6",
+        "@types/node": "^20.11.5",
+        "@types/prompts": "^2.4.9",
+        "@types/sinonjs__fake-timers": "^8.1.5",
+        "@vitest/expect": "1.6.0",
+        "@vitest/runner": "1.6.0",
+        "@vitest/snapshot": "1.6.0",
+        "@vitest/spy": "1.6.0",
+        "@vitest/utils": "1.6.0",
+        "acorn-walk": "^8.3.2",
+        "birpc": "0.2.15",
+        "cac": "^6.7.14",
+        "chai": "^4.3.10",
+        "chai-subset": "^1.6.0",
+        "cli-truncate": "^4.0.0",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "expect-type": "^0.17.3",
+        "fast-glob": "^3.3.2",
+        "find-up": "^6.3.0",
+        "flatted": "^3.2.9",
+        "get-tsconfig": "^4.7.3",
+        "happy-dom": "^14.3.10",
+        "jsdom": "^24.0.0",
+        "local-pkg": "^0.5.0",
+        "log-update": "^5.0.1",
+        "magic-string": "^0.30.5",
+        "micromatch": "^4.0.5",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "pretty-format": "^29.7.0",
+        "prompts": "^2.4.2",
+        "std-env": "^3.5.0",
+        "strip-ansi": "^7.1.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.0",
+        "why-is-node-running": "^2.2.2",
+        "ws": "^8.14.2"
+      }
+    },
+    "yjs": {
+      "version": "file:../../node_modules/.pnpm/yjs@13.6.16/node_modules/yjs",
+      "requires": {
+        "@rollup/plugin-commonjs": "^24.0.1",
+        "@rollup/plugin-node-resolve": "^15.0.1",
+        "@types/node": "^18.15.5",
+        "concurrently": "^3.6.1",
+        "http-server": "^0.12.3",
+        "jsdoc": "^3.6.7",
+        "lib0": "^0.2.86",
+        "markdownlint-cli": "^0.23.2",
+        "rollup": "^3.20.0",
+        "standard": "^16.0.4",
+        "tui-jsdoc-template": "^1.2.2",
+        "typescript": "^4.9.5",
+        "y-protocols": "^1.0.5"
+      }
+    }
+  }
+}

--- a/packages/react-yjs/package.json
+++ b/packages/react-yjs/package.json
@@ -23,7 +23,8 @@
     "dev": "tsup --watch"
   },
   "dependencies": {
-    "lib0": "^0.2.94"
+    "lib0": "^0.2.94",
+    "use-sync-external-store": "^1.2.2"
   },
   "peerDependencies": {
     "react": "^18 || ^19",
@@ -34,6 +35,7 @@
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^16.0.0",
     "@types/react": "^18.2.66",
+    "@types/use-sync-external-store": "^0.0.6",
     "react": "^18.2.0",
     "vite": "^5.2.13",
     "vitest": "^1.6.0",

--- a/packages/react-yjs/src/useY.ts
+++ b/packages/react-yjs/src/useY.ts
@@ -1,5 +1,6 @@
 import { equalityDeep } from "lib0/function";
-import { useRef, useSyncExternalStore } from "react";
+import { useRef } from "react";
+import { useSyncExternalStore } from "use-sync-external-store/shim";
 import * as Y from "yjs";
 import { YJsonValue } from "./types.js";
 


### PR DESCRIPTION
Uses shim so that the library would work with versions of react before 18 :)