### PR TITLE
Fix typing when `useY` is used with `Y.Text`

### DIFF
--- a/packages/react-yjs/src/useY.ts
+++ b/packages/react-yjs/src/useY.ts
@@ -8,7 +8,7 @@ type YTypeToJson<YType> =
     ? Array<YTypeToJson<Value>>
     : YType extends Y.Map<infer MapValue>
       ? { [key: string]: YTypeToJson<MapValue> }
-      : YType extends Y.XmlFragment | Y.XmlText
+      : YType extends Y.XmlFragment | Y.XmlText | Y.Text
         ? string
         : YType;
 


### PR DESCRIPTION
```ts
const value = useY(yText)
```

Previously, `value` was of type `Y.Text`. This PR fixed this and now `value` is correctly of type `string.`

The typing in the source code does not have `Y.XmlElement` but that type extends `Y.XmlFragment` so it should already work well for this case.

Fixes #8.